### PR TITLE
Setup integrate test coverage reporting

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: z8VNUo5FYd0xYmhaJG5psLlFAOk32S94V

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Ride-my-way
 
 [![Build Status](https://travis-ci.org/joeeasy/Ride-my-way.svg?branch=develop)](https://travis-ci.org/joeeasy/Ride-my-way)
+[![Coverage Status](https://coveralls.io/repos/github/joeeasy/Ride-my-way/badge.svg?branch=develop)](https://coveralls.io/github/joeeasy/Ride-my-way?branch=develop)


### PR DESCRIPTION
[Finishes #158474319] Integrate test coverage reporting (e.g. Coveralls) with badge in the ​ ReadMe.